### PR TITLE
Update thread-generator to call Netlify Function

### DIFF
--- a/thread-generator.html
+++ b/thread-generator.html
@@ -249,29 +249,13 @@
             
               // Claude API Integration
     try {
-      const CLAUDE_API_KEY = 'sk-ant-api03-f8mO5vEVvIs0rGbm8guTR2vqhVCYN6mBVKOnIpcwuZcLJsO4qhuw9GQ391X67PsZdMq0POnW_7SpnF4P0DldlA--7qPQQAA';
-      const CLAUDE_API_URL = 'https://api.anthropic.com/v1/messages';
-      
-      const prompt = `Create a Twitter/X thread about "${topic}" with ${length} tweets.
-Tone: ${tone}.
-Format each tweet clearly numbered (1/, 2/, etc.) and ensure each tweet is under 280 characters.
-Make the thread engaging, valuable, and aligned with the mystical "Oracle" theme of Kypria Technologies.`;
-      
-      const response = await fetch(CLAUDE_API_URL, {
+      // Call Netlify Function
+      const response = await fetch('/.netlify/functions/generate-thread', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': CLAUDE_API_KEY,
-          'anthropic-version': '2023-06-01'
+          'Content-Type': 'application/json'
         },
-        body: JSON.stringify({
-          model: 'claude-3-sonnet-20240229',
-          max_tokens: 2048,
-          messages: [{
-            role: 'user',
-            content: prompt
-          }]
-        })
+        body: JSON.stringify({ topic, length, tone })
       });
       
       const data = await response.json();


### PR DESCRIPTION
Replace direct Claude API calls with Netlify Function endpoint.

- Changed fetch URL from Claude API to /.netlify/functions/generate-thread
- Removed API key and URL constants (now handled server-side)
- Simplified request body to just { topic, length, tone }
- Maintains same response parsing and tweet display logic

This fixes CORS issues and secures the API key server-side.