### PR TITLE
Fix Netlify Function: Use native fetch API

### DIFF
--- a/netlify/functions/generate-thread.js
+++ b/netlify/functions/generate-thread.js
@@ -1,5 +1,3 @@
-const fetch = require('node-fetch');
-
 exports.handler = async (event) => {
   // Only allow POST requests
   if (event.httpMethod !== 'POST') {


### PR DESCRIPTION
Remove node-fetch dependency and use native fetch API available in modern Netlify Functions (Node.js 18+).

This fixes the function execution error and enables the Thread Generator to work properly.